### PR TITLE
small fixes for derep command

### DIFF
--- a/src/polish/PurgeDups.hpp
+++ b/src/polish/PurgeDups.hpp
@@ -313,7 +313,8 @@ public:
 
 		string contigFilenameBgzip = _tmpDir + "/__tmp_contigs_bgzip.fasta.gz";
 
-		string command = "zcat " + _inputFilename_contigs + " | bgzip --threads " + to_string(_nbCores) + " -c > " + contigFilenameBgzip;
+		string catCmd = (_inputFilename_contigs.rfind(".gz") != _inputFilename_contigs.size()-3) ? "cat" : "zcat";
+		string command = catCmd + " " + _inputFilename_contigs + " | bgzip --threads " + to_string(_nbCores) + " -c > " + contigFilenameBgzip;
 		Utils::executeCommand(command, _outputDir, _logFile);
 
 		command = "samtools faidx " + contigFilenameBgzip;

--- a/src/polish/PurgeDups.hpp
+++ b/src/polish/PurgeDups.hpp
@@ -235,8 +235,8 @@ public:
 		}
 
 		fs::path outputContigPath(_outputFilename_contigs);
-		string contigDir = outputContigPath.parent_path();
-		if(!fs::exists(contigDir)){
+		fs::directory_entry contigDir(outputContigPath.parent_path());
+		if(!contigDir.path().empty() && !contigDir.exists()){
 			fs::create_directories(contigDir);
 		}
 


### PR DESCRIPTION
Fixed two small problems for `metaMDBG derep`:
- the output file is in current directory, (and provided with no heading `./`), which leads to a crash
- use of `cat` or `zcat` depending on input contig file extension

Other known issue:
- In file `src/polish/PurgeDups.hpp` the use of `Utils::contigName_to_contigIndex(read._header)` inside the function `dumpDereplicatedContigs_read` limits the tool to be used only with contigs named with a `ctg` prefix. An simple way to fix it would be to simply write `contigName` in the output file (however I do not know if it would break the main assembly tool).